### PR TITLE
Changed Message Label Color to White

### DIFF
--- a/FoundationChat/Views/ConversationDetail/ConversationMessageView.swift
+++ b/FoundationChat/Views/ConversationDetail/ConversationMessageView.swift
@@ -10,6 +10,7 @@ struct ConversationMessageView: View {
       }
       VStack(alignment: .leading) {
         Text(message.content)
+          .foregroundStyle(.white)
           .font(.subheadline)
           .contentTransition(.interpolate)
           .animation(.bouncy, value: message.content)


### PR DESCRIPTION
Changed Message Label Color to White for a better look in Light Mode where the Chat Bubbles look a bit off with a black label text